### PR TITLE
Metadata optimization

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -4,6 +4,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Personal sites are awesome</title>
+    <meta name="description" content="Personal sites are awesome, so this site was built so we can all discover each others. This directory of links are by folks that want to share their site with the world.">
+    <meta property="og:url" content="https://personalsit.es/">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Personal sites are awesome">
+    <meta property="og:description" content="Personal sites are awesome, so this site was built so we can all discover each others. This directory of links are by folks that want to share their site with the world.">
+    <meta property="og:image" content="/assets/images/apple-touch-icon.png">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Personal sites are awesome">
+    <meta name="twitter:description" content="Personal sites are awesome, so this site was built so we can all discover each others. This directory of links are by folks that want to share their site with the world.">
+    <meta name="twitter:image" content="/assets/images/apple-touch-icon.png">
     <style>{% include "assets/css/global.css" %}</style>
     {% for feed in feeds.items %}
         <link rel="alternate" type="application/rss+xml" title="{{ feed.text }}" href="{{ feed.url }}" />

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -9,11 +9,11 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="Personal sites are awesome">
     <meta property="og:description" content="Personal sites are awesome, so this site was built so we can all discover each others. This directory of links are by folks that want to share their site with the world.">
-    <meta property="og:image" content="/assets/images/apple-touch-icon.png">
+    <meta property="og:image" content="https://personalsit.es/assets/images/apple-touch-icon.png">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="Personal sites are awesome">
     <meta name="twitter:description" content="Personal sites are awesome, so this site was built so we can all discover each others. This directory of links are by folks that want to share their site with the world.">
-    <meta name="twitter:image" content="/assets/images/apple-touch-icon.png">
+    <meta name="twitter:image" content="https://personalsit.es/assets/images/apple-touch-icon.png">
     <style>{% include "assets/css/global.css" %}</style>
     {% for feed in feeds.items %}
         <link rel="alternate" type="application/rss+xml" title="{{ feed.text }}" href="{{ feed.url }}" />

--- a/sites/scottmathson.com.md
+++ b/sites/scottmathson.com.md
@@ -1,0 +1,8 @@
+---
+title: 'scottmathson.com'
+url: 'https://scottmathson.com/'
+tags: ['web developer', 'web designer', 'seo', 'maker']
+updatesFeed: 'https://scottmathson.com/feed.xml'
+nsfw: false
+rss: true
+---

--- a/sites/scottmathson.com.md
+++ b/sites/scottmathson.com.md
@@ -1,8 +1,0 @@
----
-title: 'scottmathson.com'
-url: 'https://scottmathson.com/'
-tags: ['web developer', 'web designer', 'seo', 'maker']
-updatesFeed: 'https://scottmathson.com/feed.xml'
-nsfw: false
-rss: true
----


### PR DESCRIPTION
Adding a description for search (we could rewrite title/descrip if wanting, too)
Added meta tags for open graph and twitter, social sharing.
Using favicon asset and ensured setting Twitter card to summary (small).

![Twitter card validator view pre-metadata-addition](https://user-images.githubusercontent.com/25587929/53211520-b0760280-35fe-11e9-9682-72e635774c29.png)
(current)
![Twitter search - tweets including https://personalsit.es/](https://user-images.githubusercontent.com/25587929/53211592-f632cb00-35fe-11e9-9344-6506207446fb.png)
