### PR TITLE
change www.paulgo.io to about.paulgo.io

### DIFF
--- a/sites/about.paulgo.io.md
+++ b/sites/about.paulgo.io.md
@@ -1,6 +1,6 @@
 ---
 title: 'Paul Braeuning - Portfolio'
-url: 'https://www.paulgo.io'
+url: 'https://about.paulgo.io'
 tags: ['student', 'computer science', 'docker']
 nsfw: false
 rss: false


### PR DESCRIPTION
I added my site in #454. Since then the URL changed to https://about.paulgo.io; So this PR is to update to the new URL.