### PR TITLE
Fix typo on garethjoyce URL

### DIFF
--- a/sites/garethjoyce.co.uk.md
+++ b/sites/garethjoyce.co.uk.md
@@ -1,6 +1,6 @@
 ---
 title: 'garethjoyce.co.uk'
-url: 'https://ww.garethjoyce.co.uk'
+url: 'https://www.garethjoyce.co.uk'
 tags: ['design', 'accessibility', 'mental health']
 nsfw: false
 rss: false


### PR DESCRIPTION
Just noticed it in the build output:

<img width="964" height="379" alt="Screenshot 2025-11-25 at 21 28 45" src="https://github.com/user-attachments/assets/1660e65b-4d35-40b6-89e0-5078d27d861b" />
