### PR TITLE
♿️ - Fix a11y issue for missing alt text

### DIFF
--- a/_includes/partials/list-item.njk
+++ b/_includes/partials/list-item.njk
@@ -17,7 +17,7 @@
     </div>
     <div class="item-tray">
         <div class="item-tray__inner">
-            <img class="item-tray__image" data-src="{% cdnUrl item.data.url %}" height="375" width="600" />
+            <img class="item-tray__image" data-src="{% cdnUrl item.data.url %}" height="375" width="600" alt="" />
             <div class="item-tray__column">
                 <div class="item-tray__site-title">{{ item.data.title }}</div>
                 <a class="item-tray__url" href="{{ item.data.url }}">{{ item.data.url }}</a>


### PR DESCRIPTION
Adds `alt=""` to the `<img>` in the details section of list items.

The clickable image displayed in the grid correctly had `alt=""`, marking it as decorative, but the second image didn't have the `alt` attribute at all.

---

Alternatively, each of these images _could_ have something like `alt="The homepage of {{ item.data.url  }}"`, but that feels like it wouldn't create a good screen reader experience. 

It doesn't add much information (kind of redundant), and it would be pretty repetetive for a screen reader to announce them, especially since there are 800+ websites in the list.

Helpful reference for decorative images:
https://www.w3.org/WAI/tutorials/images/decorative/