### PR TITLE
Update ozgur.ca tags + request screenshot refresh

### DIFF
--- a/sites/ozgur.ca.md
+++ b/sites/ozgur.ca.md
@@ -1,6 +1,6 @@
 ---
 title: 'Oz Gultekin'
 url: 'https://ozgur.ca'
-tags: ['design', 'writing', 'photography']
+tags: ['design', 'writing', 'photography', 'projects', 'colours']
 rss: 'https://ozgur.ca/rss.xml'
 ---


### PR DESCRIPTION
Added a couple more tags to better reflect the site. The current screenshot was captured mid-animation which has since been removed. Could you delete the existing S3 screenshot so it regenerates on merge?

<img width="1200" height="750" alt="ozgur-ca-screenshot" src="https://github.com/user-attachments/assets/37e8eedc-bf01-49fc-8b9c-1335ddae19be" />