### PR TITLE
feat: Add hawksley.dev

### DIFF
--- a/sites/hawksley.dev.md
+++ b/sites/hawksley.dev.md
@@ -1,0 +1,6 @@
+---
+title: 'Ethan Hawksley'
+url: 'https://hawksley.dev'
+tags: ['systems programming', 'cybersecurity']
+rss: 'https://hawksley.dev/rss.xml'
+---


### PR DESCRIPTION
Added [hawksley.dev](https://hawksley.dev) to the list of sites.
I've classified it under systems programming and cybersecurity, and added my rss feed.
It's impressive how many there are so far :)