### PR TITLE
Add stimmie.dev

### DIFF
--- a/sites/stimmie.dev.md
+++ b/sites/stimmie.dev.md
@@ -1,0 +1,5 @@
+---
+title: 'Stimmie'
+url: 'https://stimmie.dev'
+tags: ['software engineer', 'portfolio', 'next.js', 'philippines', 'personal site']
+---


### PR DESCRIPTION
## Summary

Adds [stimmie.dev](https://stimmie.dev) to the PersonalSit.es directory.

```yaml
---
title: 'Stimmie'
url: 'https://stimmie.dev'
tags: ['software engineer', 'portfolio', 'next.js', 'philippines', 'personal site']
---
```

Personal homepage — software engineer portfolio with talks, projects, blog, and a neo-brutalist / scrapbook aesthetic. Custom domain on HTTPS.