### PR TITLE
Add aogavrilov.com

### DIFF
--- a/sites/aogavrilov.com.md
+++ b/sites/aogavrilov.com.md
@@ -1,0 +1,6 @@
+---
+title: 'Alexey Gavrilov'
+url: 'https://aogavrilov.com/'
+tags: ['machine learning', 'research', 'academic']
+rss: 'https://aogavrilov.com/atom.xml'
+---


### PR DESCRIPTION
Adds my personal research site and its Atom feed. The site is noncommercial and contains publications and research notes; I am the site owner.

I also ran the Eleventy build locally and confirmed the entry appears in the main directory and feed-only view.